### PR TITLE
Update next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,10 +4,17 @@ import rehypePrism from '@mapbox/rehype-prism'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "export",
+  distDir: "output",
+  basePath: '',
   pageExtensions: ['js', 'jsx', 'mdx'],
   reactStrictMode: true,
   experimental: {
     scrollRestoration: true,
+  },
+  images: {
+    unoptimized: true,
+    path: ".",
   },
 }
 


### PR DESCRIPTION
In this updated configuration:
The images configuration is moved outside of the .experimental section. It's now directly under the top-level configuration object. This should resolve the invalid options warning related to the images property.