### PR TITLE
Fix 'invalid <Link> with <a> child.' error

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -17,10 +17,8 @@ export function Banner() {
               Learn how to apply for an opportunity to work on open-source projects and gain real-world experience through Google Summer of Code.
             </p>
             <div className="mt-5">
-              <Link href="/apply">
-                <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
+              <Link href="/apply" className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
                   Apply to GSoC with AOSSIE
-                </a>
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Fixing "Invalid `<Link>` with `<a>` child." error

Steps to reproduce this error:

1. Clone the repository.
2. `cd website`.
3. Run `npm install`.
4. Run `npm run dev`.

![image](https://github.com/AOSSIE-Org/website/assets/70969910/405fb7a8-9892-4ea1-abdf-9846b069f373)
