### PR TITLE
Comment out 'Know More' links due to missing data #66

### DIFF
--- a/src/pages/ideas/index.jsx
+++ b/src/pages/ideas/index.jsx
@@ -13,7 +13,7 @@ function Article({ article }) {
           {article.title}
         </Card.Title>
         <Card.Description>{article.description}</Card.Description>
-        <Card.Cta>Know More</Card.Cta>
+        {/* <Card.Cta>Know More</Card.Cta> */}
       </Card>
     </article>
   )


### PR DESCRIPTION
**RESOLVED #66 **

_**Description:**_

This pull request addresses the issue where the "Know More" links under project descriptions currently lead to non-existent pages. To improve user experience and avoid confusion, these links have been temporarily commented out until relevant data or information becomes available.

_**Changes Made:**_

Commented out the "Know More" links in the project descriptions.
Added comments in the code indicating that these links are temporary and should be restored once the necessary data is provided.

_**Reason for Change:**_

The links were leading nowhere, which could potentially confuse users. By commenting them out, we ensure a cleaner and more informative user interface while we work on gathering and integrating the necessary information.

Please review the changes and provide feedback. If everything looks good, we can proceed with merging this PR to keep our homepage accurate and user-friendly.

Thanks