### PR TITLE
Update Hover Color for Dark Mode

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -17,10 +17,8 @@ export function Banner() {
               Learn how to apply for an opportunity to work on open-source projects and gain real-world experience through Google Summer of Code.
             </p>
             <div className="mt-5">
-              <Link href="/apply">
-                <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
-                  Apply to GSoC with AOSSIE
-                </a>
+            <Link href="/apply" className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
+            Apply to GSoC with AOSSIE
               </Link>
             </div>
           </div>

--- a/src/components/CardEffect.jsx
+++ b/src/components/CardEffect.jsx
@@ -1,8 +1,9 @@
-import Image from 'next/image'
+import Image from 'next/image';
+import Link from 'next/link'
 
 export function CardEffect({heading, content, logo}) {
     return (
-        <a className="group relative block h-[22rem] max-lg:w-72 max-xl:w-60 w-72 cursor-pointer">
+        <Link href="#" className="group relative block h-[22rem] max-lg:w-72 max-xl:w-60 w-72 cursor-pointer">
             {/* <span className="absolute inset-0 border-2 rounded-lg border-dashed border-black dark:border-zinc-300"></span> */}
 
             {/* <div className="relative flex h-full transform items-end border-4 rounded-lg border-black dark:border-zinc-300 bg-transparent dark:bg-transparent transition-transform group-hover:-translate-x-2 group-hover:-translate-y-2"> */}
@@ -22,6 +23,6 @@ export function CardEffect({heading, content, logo}) {
                     <p className="mt-4 font-mono sm:w-100 w-52">{content}</p>
                 </div>
             </div>
-        </a>
+        </Link>
     )
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -36,16 +36,16 @@ export function Footer() {
                 <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com'>
                   <FontAwesomeIcon icon={faEnvelope} size='xl' />
                 </Link>
-                <Link aria-label="Follow on GitLab" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://gitlab.com/aossie'>
+                <Link aria-label="Follow on GitLab" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-[#F97316] transition' href='https://gitlab.com/aossie'>
                   <FontAwesomeIcon icon={faGitlab} size='xl' />
                 </Link>
                 <Link aria-label="Follow on GitHub" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org'>
                   <FontAwesomeIcon icon={faGithub} size='xl' />
                 </Link>
-                <Link aria-label="Join on Discord" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.com/invite/6mFZ2S846n'>
+                <Link aria-label="Join on Discord" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-[#6D28D9] transition' href='https://discord.com/invite/6mFZ2S846n'>
                   <FontAwesomeIcon icon={faDiscord} size='xl' />
                 </Link>
-                <Link aria-label="Follow on Twitter" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://twitter.com/aossie_org'>
+                <Link aria-label="Follow on Twitter" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-[#1DA1F2] transition' href='https://twitter.com/aossie_org'>
                   <FontAwesomeIcon icon={faTwitter} size='xl' />
                 </Link>
               </div>

--- a/src/components/TimelineElement.jsx
+++ b/src/components/TimelineElement.jsx
@@ -1,6 +1,13 @@
-import clsx from "clsx"
+import clsx from "clsx";
+import Link from 'next/link';
 
 export function TimelineElement({ title, description, button, time, link, classCondition }) {
+     // Log link to check if it's undefined
+     console.log('TimelineElement link:', link);
+
+     // Ensure link is defined and not empty
+     const validLink = link || '#';
+ 
     return (
         <li className="mb-10 ml-6">
             <span className="absolute flex items-center justify-center w-6 h-6 bg-green-100 rounded-full -left-3 ring-8 ring-white dark:ring-zinc-900 dark:bg-yellow-900 scale-150">
@@ -11,7 +18,7 @@ export function TimelineElement({ title, description, button, time, link, classC
             <h3 className="flex font-mono tracking-tighter items-center mb-1 text-xl font-bold text-gray-900 dark:text-white ml-2">{title}</h3>
             <time className="block mb-2 font-mono text-sm font-normal leading-none text-gray-400 dark:text-gray-500">{time}</time>
             <p className="mb-4 font-mono tracking-tight text-base font-normal text-gray-500 dark:text-gray-400 ml-2">{description}</p>
-            <a href={link} className={clsx(classCondition,"inline-flex font-mono items-center px-4 py-2 text-sm font-bold text-gray-900 bg-white border-2 border-gray-200 rounded-lg hover:bg-gray-100 hover:text-green-700 focus:z-10 focus:ring-2 focus:outline-none focus:ring-gray-300 focus:text-green-700 dark:bg-zinc-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 dark:focus:ring-gray-700")}>{button}</a>
+            <Link href={link} className={clsx(classCondition,"inline-flex font-mono items-center px-4 py-2 text-sm font-bold text-gray-900 bg-white border-2 border-gray-200 rounded-lg hover:bg-gray-100 hover:text-green-700 focus:z-10 focus:ring-2 focus:outline-none focus:ring-gray-300 focus:text-green-700 dark:bg-zinc-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 dark:focus:ring-gray-700")}>{button}</Link>
         </li>
     )
 }


### PR DESCRIPTION
### Description
This PR updates the hover color for elements in dark mode to improve visual clarity and maintain consistent styling. The new color scheme enhances the contrast and readability of interactive elements against dark backgrounds.

#### Changes include:
- Modified hover color for [specific element/component] in dark mode.
- Ensured consistency with the overall dark mode theme.

####ScreenShot:
<img width="1261" alt="Screenshot 2024-08-03 at 2 11 12 PM" src="https://github.com/user-attachments/assets/aba81e96-b8d6-4f02-b1af-060963b4ce07">
<img width="1261" alt="Screenshot 2024-08-03 at 2 11 06 PM" src="https://github.com/user-attachments/assets/9b7b0ad3-8064-416d-8046-3b0e4cbf9127">


Please review the changes and let me know if any further adjustments are needed.