### PR TITLE
Added the INSTA ICON at the bottom of the about page

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -17,7 +17,7 @@ export function Banner() {
               Learn how to apply for an opportunity to work on open-source projects and gain real-world experience through Google Summer of Code.
             </p>
             <div className="mt-5">
-              <Link href="/apply">
+              <Link href="/apply" legacyBehavior>
                 <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
                   Apply to GSoC with AOSSIE
                 </a>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,9 +1,8 @@
 import Link from 'next/link'
-
 import { Container } from '@/components/Container'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
-import { faDiscord, faGithub, faGitlab, faTwitter } from '@fortawesome/free-brands-svg-icons'
+import { faDiscord, faGithub, faGitlab, faTwitter, faInstagram } from '@fortawesome/free-brands-svg-icons'
 
 function NavLink({ href, children }) {
   return (
@@ -33,20 +32,23 @@ export function Footer() {
                 &copy; 2016-2023 AOSSIE. All rights reserved.
               </p>
               <div className="flex gap-6">
-                <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com'>
+                <Link aria-label="Contact by Mail" className='text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com'>
                   <FontAwesomeIcon icon={faEnvelope} size='xl' />
                 </Link>
-                <Link aria-label="Follow on GitLab" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://gitlab.com/aossie'>
+                <Link aria-label="Follow on GitLab" className='text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://gitlab.com/aossie'>
                   <FontAwesomeIcon icon={faGitlab} size='xl' />
                 </Link>
-                <Link aria-label="Follow on GitHub" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org'>
+                <Link aria-label="Follow on GitHub" className='text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org'>
                   <FontAwesomeIcon icon={faGithub} size='xl' />
                 </Link>
-                <Link aria-label="Join on Discord" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.com/invite/6mFZ2S846n'>
+                <Link aria-label="Join on Discord" className='text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.com/invite/6mFZ2S846n'>
                   <FontAwesomeIcon icon={faDiscord} size='xl' />
                 </Link>
-                <Link aria-label="Follow on Twitter" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://twitter.com/aossie_org'>
+                <Link aria-label="Follow on Twitter" className='text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://twitter.com/aossie_org'>
                   <FontAwesomeIcon icon={faTwitter} size='xl' />
+                </Link>
+                <Link aria-label="Follow on Instagram" className='text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://www.instagram.com/aossie_gsoc/'>
+                  <FontAwesomeIcon icon={faInstagram} size='xl' />
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
**Summary:**
This pull request addresses issue #107 by adding an Instagram icon to the social media links section in the footer of the website. The new icon is styled consistently with the existing social media icons and links to the official Instagram page for AOSSIE.

**Changes Made:**
1. **Updated the Footer Component:**
   - Imported the `faInstagram` icon from `@fortawesome/free-brands-svg-icons`.
   - Added an Instagram link with the `aria-label` attribute for accessibility.
   - Styled the Instagram icon to match the existing social media icons.
   - Updated the `href` attribute to link to `https://www.instagram.com/aossie_gsoc/`.

2. **Details:**
   - The Instagram icon has been added to the footer next to other social media icons such as GitHub, GitLab, Twitter, Discord, and email.
   - The icon and link have been styled to maintain consistency with the existing design and ensure proper visual integration.

**Code Changes:**
- Updated the `Footer` component in `Footer.js` to include the Instagram icon.

**Testing:**
- Verified that the Instagram icon displays correctly in both light and dark modes.
- Confirmed that clicking on the Instagram icon redirects to `https://www.instagram.com/aossie_gsoc/`.

**Additional Notes:**
- Please review the visual integration of the Instagram icon with existing social media links.
- Ensure that the changes are consistent with the overall styling and responsive design of the footer.

