### PR TITLE
Make project logo lnikable #156

### DIFF
--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -40,26 +40,26 @@ export default function Projects() {
           <SectionHeading>Active Projects</SectionHeading>
           <p className='text-zinc-600 dark:text-zinc-400 text-lg font-mono leading-7 mt-3'>The following projects are currently actively maintained and mentors are available!</p>
           <ul role="list" className="grid grid-cols-1 gap-x-12 gap-y-16 sm:grid-cols-2 lg:grid-cols-3 mt-12 mb-16">
-            {projects.map((project) => (
-              <Card as="li" key={project.name}>
-                <div className="relative z-10 flex h-20 w-20 items-center justify-center rounded-lg bg-white shadow-md shadow-zinc-800/20 ring-1 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-white/10 dark:shadow-white/10">
-                  <Image
-                    src={project.logo}
-                    alt="Project Logo"
-                    className='p-2'
-                    unoptimized
-                  />
-                </div>
-                <h2 className="mt-6 text-2xl font-semibold font-mono text-zinc-800 dark:text-zinc-100">
-                  <Card.Link href={project.link.href}>{project.name}</Card.Link>
-                </h2>
-                <Card.Description>{project.description}</Card.Description>
-                <p className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
-                  <LinkIcon className="h-6 w-6 flex-none scale-110" />
-                  <span className="ml-2">{project.link.label}</span>
-                </p>
-              </Card>
-            ))}
+          {projects.map((project) => (
+            <Card as="li" key={project.name}>
+              <a href={project.link.href} className="relative z-10 flex h-20 w-20 items-center justify-center rounded-lg bg-white shadow-md shadow-zinc-800/20 ring-1 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-white/10 dark:shadow-white/10">
+                <Image
+                  src={project.logo}
+                  alt="Project Logo"
+                  className="p-2"
+                  unoptimized
+                />
+              </a>
+              <h2 className="mt-6 text-2xl font-semibold font-mono text-zinc-800 dark:text-zinc-100">
+                <Card.Link href={project.link.href}>{project.name}</Card.Link>
+              </h2>
+              <Card.Description>{project.description}</Card.Description>
+              <p className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
+                <LinkIcon className="h-6 w-6 flex-none scale-110" />
+                <span className="ml-2">{project.link.label}</span>
+              </p>
+            </Card>
+          ))}
           </ul>
 
           {/* <h1 className="text-4xl font-mono font-extrabold tracking-tighter text-zinc-800 dark:text-zinc-100">


### PR DESCRIPTION
RESOLVED ISSUE : #156 

This pull request addresses the enhancement of the project list by making the project logos clickable. Currently, users can only navigate to a project page by clicking on the project name. This update will improve user experience by allowing the project logos to function as clickable links, directing users to the same project URL.

### Changes Made:

Wrapped the project logo in an anchor (<a>) tag to make it clickable.
Ensured the logo maintains its existing styling and functionality.