### PR TITLE
Update copyright year to footer

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -17,11 +17,11 @@ export function Banner() {
               Learn how to apply for an opportunity to work on open-source projects and gain real-world experience through Google Summer of Code.
             </p>
             <div className="mt-5">
-              <Link href="/apply">
-                <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
-                  Apply to GSoC with AOSSIE
-                </a>
-              </Link>
+            <Link href="/apply" legacyBehavior>
+      <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white :bg-black px-8 py-3 text-black dark:text-black focus:outline-none font-mono font-semibold cursor-pointer transition-transform duration-300 ease-in-out hover:bg-yellow-100 dark:hover:bg-yellow-200 hover:shadow-lg">
+        Apply to GSoC with AOSSIE
+      </a>
+    </Link>
             </div>
           </div>
         </ContainerPattern>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -30,7 +30,7 @@ export function Footer() {
                 <NavLink href="/apply">Apply</NavLink>
               </div>
               <p className="text-sm text-zinc-400 dark:text-zinc-500 font-mono">
-                &copy; 2016-2023 AOSSIE. All rights reserved.
+                &copy; 2016-2024 AOSSIE. All rights reserved.
               </p>
               <div className="flex gap-6">
                 <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com'>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -2,6 +2,8 @@ import Head from 'next/head'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useState, useEffect } from 'react'
+import { faLinkedin } from '@fortawesome/free-brands-svg-icons';
+
 
 import { Container } from '@/components/Container'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -85,6 +87,13 @@ export default function Home() {
                   href="https://twitter.com/aossie_org"
                 >
                   <FontAwesomeIcon icon={faTwitter} size="2xl" />
+                </Link>
+                <Link
+                  aria-label="Join on LinkedIn"
+                  className="text-zinc-500 transition hover:text-[#0077B5] dark:text-zinc-400 dark:hover:text-yellow-400"
+                  href="https://www.linkedin.com/company/aossie_org"
+                >
+                  <FontAwesomeIcon icon={faLinkedin} size="2xl" />
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
resolved issue #147 

Updated the footer copyright notice to reflect the year 2024.

![CopyrightYear](https://github.com/user-attachments/assets/ef6fdadf-f855-4c60-8032-628588090f2c)
