### PR TITLE
 External links now open in a new tab 

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -17,7 +17,7 @@ export function Banner() {
               Learn how to apply for an opportunity to work on open-source projects and gain real-world experience through Google Summer of Code.
             </p>
             <div className="mt-5">
-              <Link href="/apply">
+              <Link href="/apply" legacyBehavior>
                 <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
                   Apply to GSoC with AOSSIE
                 </a>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -33,7 +33,6 @@ export function Footer() {
                 &copy; 2016-2023 AOSSIE. All rights reserved.
               </p>
               <div className="flex gap-6">
-                  target="_blank"
                 <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com' target="_blank">
                   <FontAwesomeIcon icon={faEnvelope} size='xl' />
                 </Link>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -33,19 +33,20 @@ export function Footer() {
                 &copy; 2016-2023 AOSSIE. All rights reserved.
               </p>
               <div className="flex gap-6">
-                <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com'>
+                  target="_blank"
+                <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com' target="_blank">
                   <FontAwesomeIcon icon={faEnvelope} size='xl' />
                 </Link>
-                <Link aria-label="Follow on GitLab" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://gitlab.com/aossie'>
+                <Link aria-label="Follow on GitLab" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://gitlab.com/aossie' target="_blank" >
                   <FontAwesomeIcon icon={faGitlab} size='xl' />
                 </Link>
-                <Link aria-label="Follow on GitHub" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org'>
+                <Link aria-label="Follow on GitHub" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org' target="_blank" >
                   <FontAwesomeIcon icon={faGithub} size='xl' />
                 </Link>
-                <Link aria-label="Join on Discord" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.com/invite/6mFZ2S846n'>
+                <Link aria-label="Join on Discord" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.com/invite/6mFZ2S846n' target="_blank" >
                   <FontAwesomeIcon icon={faDiscord} size='xl' />
                 </Link>
-                <Link aria-label="Follow on Twitter" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://twitter.com/aossie_org'>
+                <Link aria-label="Follow on Twitter" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://twitter.com/aossie_org' target="_blank" >
                   <FontAwesomeIcon icon={faTwitter} size='xl' />
                 </Link>
               </div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -87,6 +87,7 @@ export default function Home() {
                   aria-label="Follow on Twitter"
                   className=" text-zinc-500 transition hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400"
                   href="https://twitter.com/aossie_org"
+                  target="_blank"
                 >
                   <FontAwesomeIcon icon={faTwitter} size="2xl" />
                 </Link>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -79,6 +79,7 @@ export default function Home() {
                   aria-label="Join on Discord"
                   className=" text-zinc-500 transition hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400"
                   href="https://discord.com/invite/6mFZ2S846n"
+                  target="_blank"
                 >
                   <FontAwesomeIcon icon={faDiscord} size="2xl" />
                 </Link>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -55,6 +55,7 @@ export default function Home() {
                   aria-label="Contact by Mail"
                   className=" text-zinc-500 transition hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400"
                   href="mailto:aossie.oss@gmail.com"
+                  target="_blank"
                 >
                   <FontAwesomeIcon icon={faEnvelope} size="2xl" />
                 </Link>
@@ -62,6 +63,7 @@ export default function Home() {
                   aria-label="Follow on GitLab"
                   className=" text-zinc-500 transition hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400"
                   href="https://gitlab.com/aossie"
+                  target="_blank"
                 >
                   <FontAwesomeIcon icon={faGitlab} size="2xl" />
                 </Link>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -71,6 +71,7 @@ export default function Home() {
                   aria-label="Follow on GitHub"
                   className=" text-zinc-500 transition hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400"
                   href="https://github.com/AOSSIE-Org"
+                  target="_blank"
                 >
                   <FontAwesomeIcon icon={faGithub} size="2xl" />
                 </Link>


### PR DESCRIPTION
### Description

#### Issue
External links on the website were opening in the same tab instead of opening in a new tab.

**To Reproduce:**
1. Go to any page with an external link.
2. Click on the external link.
3. Observe that the link opens in the same tab.

**Expected Behavior:**
External links should open in a new tab, not in the same tab.

#### Solution
The issue has been resolved by adding `target="_blank"` to all external links.

#### Environment
- **OS:** Windows 11
- **Browser:** Chrome
- **Version:** 23H2

#### Changes Made
- Added `target="_blank"` attribute to external links throughout the site.

This PR addresses issue #75.