### PR TITLE
Fixed the Idea Card that was only clickable in the bottom

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -17,7 +17,7 @@ export function Banner() {
               Learn how to apply for an opportunity to work on open-source projects and gain real-world experience through Google Summer of Code.
             </p>
             <div className="mt-5">
-              <Link href="/apply">
+              <Link href="/apply" legacyBehavior>
                 <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
                   Apply to GSoC with AOSSIE
                 </a>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -43,11 +43,21 @@ Card.Title = function CardTitle({ as: Component = 'h2', href, children }) {
   )
 }
 
-Card.Description = function CardDescription({ children }) {
-  return (
+Card.Description = function CardDescription({ href, children }) {
+  const content = (
     <p className="relative z-10 mt-2 text-sm font-mono text-zinc-600 dark:text-zinc-400">
       {children}
     </p>
+  )
+  
+  return href ? (
+    <Card.Link href={href}>
+      <span className="relative z-10 block text-sm font-mono text-zinc-600 dark:text-zinc-400 hover:underline">
+        {children}
+      </span>
+    </Card.Link>
+  ) : (
+    content
   )
 }
 


### PR DESCRIPTION
This PR fixes #74 

Earlier Behaviour :
The idea card was only clickable at the bottom 

Current Behaviour :
The whole card is clickable

Testing :

https://github.com/user-attachments/assets/4e82f24e-2657-450a-9dd2-91cba37099c9

This ensures the card is clickable as a whole