### PR TITLE
#194 - Fixed typo: change Th to The in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the assets required to build the **AOSSIE's website**. 
 
 Contributions to the project are very much welcomed! Please reach out with ideas for new content or issues with existing content!
 
-Th website is a **Next.js** project using **Tailwind** for styling and design.
+The website is a **Next.js** project using **Tailwind** for styling and design.
 
 # **Getting Started**
 


### PR DESCRIPTION
ISSUE NUMBER : #194
### Overview

This pull request fixes a typo in the project documentation where "Th" was incorrectly used instead of "The."

### Changes Made

- Corrected the text from "Th website is a Next.js project using Tailwind for styling and design" to "The website is a Next.js project using Tailwind for styling and design."

### Impact

- This is a minor text correction and does not affect any functionality or logic. It improves the readability and professionalism of the documentation.