### PR TITLE
Fixed the broken link on OpenChat Project on projects page

### DIFF
--- a/src/helper/projects.js
+++ b/src/helper/projects.js
@@ -54,7 +54,7 @@ const projects = [
     name: 'OpenChat',
     description:
       'a decentralised platform for secure and private messaging and file sharing built on top of blockchain',
-    link: { href: '#', label: 'OpenChat' },
+    link: { href: 'https://github.com/AOSSIE-Org/OpenPeerChat-flutter', label: 'OpenChat' },
     logo: DefaultLogo,
   },
   {


### PR DESCRIPTION
This PR fixes #196 
Summary:
This PR addresses the issue where the "OpenChat Project" on the Projects page did not redirect to the appropriate project details page. The link has been fixed to ensure proper navigation and improve user experience.

Changes:

Corrected the hyperlink for the "OpenChat Project" to point to the correct project details page.
Details:

Before Change: Clicking on the "OpenChat Project" link on the Projects page did not redirect to any page, leading to a broken or unresponsive link.
After Change: The "OpenChat Project" link now correctly redirects to the project details page, allowing users to access the project information seamlessly.

Testing:

https://github.com/user-attachments/assets/abe243f1-c0b9-4cf1-947c-cfb2d3c5b9a9

