### PR TITLE
Made the GSOC image in the apply section clickable

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -17,7 +17,7 @@ export function Banner() {
               Learn how to apply for an opportunity to work on open-source projects and gain real-world experience through Google Summer of Code.
             </p>
             <div className="mt-5">
-              <Link href="/apply">
+              <Link href="/apply" legacyBehavior>
                 <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
                   Apply to GSoC with AOSSIE
                 </a>

--- a/src/pages/apply.jsx
+++ b/src/pages/apply.jsx
@@ -56,7 +56,9 @@ export default function About() {
           </ol>
 
           <div className="mt-20 relative block rounded-3xl dark:bg-white/70 bg-zinc-400/20 p-8 pb-16 shadow-xl">
-            <Image src={GSoC} width={700} className='mx-auto' />
+          <a href="https://summerofcode.withgoogle.com/get-started" target="_blank" rel="noopener noreferrer">
+              <Image src={GSoC} width={700} className='mx-auto' />
+            </a>
             {/* <h3 className="text-4xl font-bold">100+</h3> */}
             {/* <h1 className="mt-4 text-4xl font-mono font-black text-gray-500">
               2024 Program Timeline


### PR DESCRIPTION
## Description
This PR addresses the issue where the Google Summer of Code logo was static and did not link to any URL. The logo is now made clickable, and upon clicking, it redirects users to the specified URL: [https://summerofcode.withgoogle.com/get-started](https://summerofcode.withgoogle.com/get-started).

## Changes Made
- Wrapped the logo in an anchor (`<a>`) tag linking to the provided URL.
- Ensured that the logo maintains its existing styling while being clickable.

## Testing
- Manually verified that clicking the logo redirects to the correct URL as expected.
- Confirmed that there are no styling or layout changes introduced by the update.

Issue: #226 