### PR TITLE
Fixes issue #239 added legacyBehavior

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -17,7 +17,7 @@ export function Banner() {
               Learn how to apply for an opportunity to work on open-source projects and gain real-world experience through Google Summer of Code.
             </p>
             <div className="mt-5">
-              <Link href="/apply">
+              <Link href="/apply" legacyBehavior>
                 <a className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
                   Apply to GSoC with AOSSIE
                 </a>


### PR DESCRIPTION
The error we're encountering is related to the use of the <Link> component from Next.js, which has changed in newer versions. Specifically, Next.js no longer allows an <a> tag as a direct child of a <Link> component without using `legacyBehavior`.

### Before Changes:

![Screenshot 2024-08-19 223030](https://github.com/user-attachments/assets/06a59dbc-6ac4-4d20-be2f-08aa6d1cc919)

### After Adding `legacyBehavior`:

![image](https://github.com/user-attachments/assets/ac23a880-84cf-4f7d-9239-061e45f368fe)

We can also fix this by removing the `<a>` tag, but that could cause issues in the future if we need to add attributes like `target` to the anchor tag.
