### PR TITLE
Fix footer social media links to open in new tabs

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -33,19 +33,19 @@ export function Footer() {
                 &copy; 2016-2023 AOSSIE. All rights reserved.
               </p>
               <div className="flex gap-6">
-                <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com'>
-                  <FontAwesomeIcon icon={faEnvelope} size='xl' />
+                <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com' target="_blank" rel="noopener noreferrer">
+                  <FontAwesomeIcon icon={faEnvelope} size='xl' /> 
                 </Link>
-                <Link aria-label="Follow on GitLab" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://gitlab.com/aossie'>
+                <Link aria-label="Follow on GitLab" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://gitlab.com/aossie' target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGitlab} size='xl' />
                 </Link>
-                <Link aria-label="Follow on GitHub" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org'>
+                <Link aria-label="Follow on GitHub" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org' target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} size='xl' />
                 </Link>
-                <Link aria-label="Join on Discord" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.com/invite/6mFZ2S846n'>
+                <Link aria-label="Join on Discord" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.com/invite/6mFZ2S846n' target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faDiscord} size='xl' />
                 </Link>
-                <Link aria-label="Follow on Twitter" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://twitter.com/aossie_org'>
+                <Link aria-label="Follow on Twitter" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://twitter.com/aossie_org' target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faTwitter} size='xl' />
                 </Link>
               </div>


### PR DESCRIPTION
This PR solves issue #248 
### Description:
This PR addresses the issue where Twitter and LinkedIn links in the footer were opening in the same tab instead of a new one. It adds the target="_blank" rel="noopener noreferrer" attribute to these links to ensure they open in new tabs, consistent with the behavior of the Mastodon link.

### Changes made:

Added target="_blank" rel="noopener noreferrer" to Twitter and LinkedIn footer links
Before / After:
Before: Twitter and LinkedIn links opened in the same tab
After: All social media links in the footer now open in new tabs

### Testing:

Navigate to any page with the footer visible
Click on each social media icon (Twitter, LinkedIn, Mastodon)
Verify that each link opens in a new tab