### PR TITLE
padding issue fix : remove unnecessary margin class

### DIFF
--- a/src/components/SectionHeading.jsx
+++ b/src/components/SectionHeading.jsx
@@ -12,7 +12,7 @@ export function SectionHeading({ number, children, className, ...props }) {
       <span className="font-mono text-base font-semibold" aria-hidden="true">
       </span>
       {/* <span className="ml-3 h-3.5 w-px bg-blue-600/20 dark:bg-white" /> */}
-      <span className="ml-3 text-base font-semibold font-mono tracking-tighter">
+      <span className=" text-base font-semibold font-mono tracking-tighter">
         {children}
       </span>
     </h2>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/59bbd7b4-4a81-4e70-b747-9e478fe557e6)

The `ml-3` tw class to the heading span was causing the issue !