### PR TITLE
343: Add text truncation for article descriptions in Ideas page

### DIFF
--- a/src/pages/ideas/index.jsx
+++ b/src/pages/ideas/index.jsx
@@ -5,6 +5,13 @@ import { Card } from '@/components/Card'
 import { Container } from '@/components/Container'
 import { getAllIdeas } from '@/helper/getAllIdeas'
 
+function truncateText(text, maxLength) {
+  if (text.length > maxLength) {
+    return text.substring(0, maxLength) + '...';
+  }
+  return text;
+}
+
 function Article({ article }) {
   return (
     <article className="mt-5 sm:mt-0 md:grid md:grid-flow-col md:grid-cols-4 md:items-baseline">
@@ -12,7 +19,7 @@ function Article({ article }) {
         <Card.Title href={`/ideas/2024/${article.slug}`}>
           {article.title}
         </Card.Title>
-        <Card.Description>{article.description}</Card.Description>
+        <Card.Description> {truncateText(article.description, 100)}</Card.Description>
         <Card.Cta>Know More</Card.Cta>
       </Card>
     </article>


### PR DESCRIPTION
Added text truncation for article descriptions in Ideas page. 
To improve the user experience and maintain a consistent design, we need to truncate descriptions that exceed a specific character limit and append an ellipsis (...) to indicate there is more text.