### PR TITLE
fixed copyright text ui issue

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -29,7 +29,7 @@ export function Footer() {
                 <NavLink href="/ideas">Ideas</NavLink>
                 <NavLink href="/apply">Apply</NavLink>
               </div>
-              <p className="text-sm text-zinc-400 dark:text-zinc-500 font-mono">
+              <p className="text-center text-sm text-zinc-400 dark:text-zinc-500 font-monoz">
                 &copy; 2016-2023 AOSSIE. All rights reserved.
               </p>
               <div className="flex gap-6">


### PR DESCRIPTION
Before Change:
![image](https://github.com/user-attachments/assets/953701a4-12e8-4316-ad49-c8712dfd8227)

After Change:
![image](https://github.com/user-attachments/assets/4f468b60-04d3-4c49-96e1-c447bfcd0c2f)


for smaller mobile devices the copyright text is not centered which gives a bad look, I fixed the issue and made copyright ui look better across all devices