### PR TITLE
#397 issue resolved

### DIFF
--- a/src/pages/apply.jsx
+++ b/src/pages/apply.jsx
@@ -35,7 +35,7 @@ export default function About() {
               title="Start Contributing"
               description="Contribute to the project and make your mark on open-source development with AOSSIE. By making a Pull Request (PR) to one of our existing projects, you'll have the opportunity to showcase your skills and demonstrate your understanding of the project. This will also give you an opportunity to work with the mentors and get familiar with the project before the official GSoC coding period starts. This is a great way to get started and increase your chances of being selected for the program."
               button="Contribute"
-              link='https://gitlab.com/aossie'
+              link='https://github.com/AOSSIE-Org'
             />
             <TimelineElement
               title="Write a Draft Application"


### PR DESCRIPTION
Title: Fix: Update Gitlab link to Github redirect

Description:
Updated the project's redirecting link from Gitlab to Github to reflect the current repository location. This change ensures users are directed to the correct and active repository.

Changes made:
- Updated the redirect URL from [old Gitlab link] to [new Github link]
