### PR TITLE
Fix: Update 'Active Projects' heading style to avoid confusion

### DIFF
--- a/src/components/SectionHeading.jsx
+++ b/src/components/SectionHeading.jsx
@@ -5,7 +5,7 @@ export function SectionHeading({ number, children, className, ...props }) {
     <h2
       className={clsx(
         className,
-        'inline-flex items-center rounded-full py-1 px-4 text-[#00843D] dark:text-yellow-400 ring-1 ring-inset ring-[#00843D] dark:ring-yellow-400'
+        'py-1text-[#00843D] dark:text-yellow-400 text-center pb-4'
       )}
       {...props}
     >


### PR DESCRIPTION
Fix: Update 'Active Projects' heading style to avoid confusion