### PR TITLE
fix: Correct year-specific ideas list loading and navigation (2022-2024)

### DIFF
--- a/src/pages/ideas/2022/index.jsx
+++ b/src/pages/ideas/2022/index.jsx
@@ -1,0 +1,121 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { Container } from '@/components/Container';
+import { getAllIdeas } from '@/helper/getAllIdeas2022';
+import Grid from '@mui/material/Grid';
+import MuiCard from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardActions from '@mui/material/CardActions';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+
+function Article({ article }) {
+    return (
+        <Grid item xs={12} sm={6} md={4}>
+            <MuiCard
+                className="dark:bg-[#2A2A2A] dark:border-white"
+                sx={{
+                    height: 350,
+                    borderRadius: 2,
+                    border: '1px solid',
+                    borderColor: '#3c982c',
+                    boxShadow: '0px 4px 4px #00000040',
+                    backdropFilter: 'blur(4px) brightness(100%)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    transition: 'background-color 0.3s ease',
+                }}
+            >
+                <CardContent sx={{ flexGrow: 1, textAlign: 'center' }}>
+                    <Typography
+                        variant="h5"
+                        className="mt-6 text-2xl font-mono text-green-600 dark:text-yellow-400"
+                        sx={{ fontFamily: 'Nunito-Bold', color: '#3c982c', textAlign: 'center' }}
+                    >
+                        {article.title}
+                    </Typography>
+
+                    <Typography
+                        variant="body1"
+                        className="text-zinc-600 text-base dark:text-zinc-400 text-lg font-mono leading-6 text-center"
+                        sx={{
+                            fontFamily: 'Nunito-Light',
+                            color: 'black',
+                            mt: 2,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            display: '-webkit-box',
+                            WebkitBoxOrient: 'vertical',
+                            WebkitLineClamp: 4,
+                        }}
+                    >
+                        {article.description}
+                    </Typography>
+                </CardContent>
+
+                <CardActions sx={{ justifyContent: 'center' }}>
+                    <Link href={`/ideas/2022/${article.slug}`} passHref>
+                        <Button
+                            sx={{
+                                color: '#3c982c',
+                                textTransform: 'none',
+                            }}
+                            className="font-Nunito-Bold text-green-600 dark:text-yellow-400 text-lg leading-7 text-center"
+                        >
+                            Know more <ArrowForwardIcon sx={{ width: 20, height: 20 }} />
+                        </Button>
+                    </Link>
+                </CardActions>
+            </MuiCard>
+        </Grid>
+    );
+}
+
+export default function Ideas({ articles }) {
+    return (
+        <>
+            <Head>
+                <title>Idea List</title>
+                <meta name="description" content="Idea List for GSOC 2022" />
+            </Head>
+
+            <Container className="mt-20 mb-28">
+                <div className="flex justify-center items-center w-full">
+                    <p className="font-mono text-lg leading-7 text-zinc-600 dark:text-zinc-400">
+                        AOSSIE&apos;s{' '}
+                        <b>Idea List</b> for{' '}
+                        <b>Google Summer of Code 2022</b>
+                    </p>
+                </div>
+
+                <Container.Inner>
+                    <div className="mt-10 sm:mt-20 flex justify-center">
+                        <Grid container spacing={4} sx={{ justifyContent: 'center' }}>
+                            {articles.map((article) => (
+                                <Article key={article.slug} article={article} />
+                            ))}
+                        </Grid>
+                    </div>
+
+                    <div className="text-center mt-16">
+                        <Link
+                            href="/ideas"
+                            className="mx-auto group rounded-lg items-center overflow-hidden bg-zinc-800 dark:bg-white px-8 py-3 text-white focus:outline-none dark:text-black"
+                        >
+                            <span className="font-mono font-semibold">Go Back</span>
+                        </Link>
+                    </div>
+                </Container.Inner>
+            </Container>
+        </>
+    );
+}
+
+export async function getStaticProps() {
+    return {
+        props: {
+            articles: (await getAllIdeas()).map(({ component, ...meta }) => meta),
+        },
+    };
+} 

--- a/src/pages/ideas/2023/index.jsx
+++ b/src/pages/ideas/2023/index.jsx
@@ -1,0 +1,121 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { Container } from '@/components/Container';
+import { getAllIdeas } from '@/helper/getAllIdeas2023';
+import Grid from '@mui/material/Grid';
+import MuiCard from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardActions from '@mui/material/CardActions';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+
+function Article({ article }) {
+    return (
+        <Grid item xs={12} sm={6} md={4}>
+            <MuiCard
+                className="dark:bg-[#2A2A2A] dark:border-white"
+                sx={{
+                    height: 350,
+                    borderRadius: 2,
+                    border: '1px solid',
+                    borderColor: '#3c982c',
+                    boxShadow: '0px 4px 4px #00000040',
+                    backdropFilter: 'blur(4px) brightness(100%)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    transition: 'background-color 0.3s ease',
+                }}
+            >
+                <CardContent sx={{ flexGrow: 1, textAlign: 'center' }}>
+                    <Typography
+                        variant="h5"
+                        className="mt-6 text-2xl font-mono text-green-600 dark:text-yellow-400"
+                        sx={{ fontFamily: 'Nunito-Bold', color: '#3c982c', textAlign: 'center' }}
+                    >
+                        {article.title}
+                    </Typography>
+
+                    <Typography
+                        variant="body1"
+                        className="text-zinc-600 text-base dark:text-zinc-400 text-lg font-mono leading-6 text-center"
+                        sx={{
+                            fontFamily: 'Nunito-Light',
+                            color: 'black',
+                            mt: 2,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            display: '-webkit-box',
+                            WebkitBoxOrient: 'vertical',
+                            WebkitLineClamp: 4,
+                        }}
+                    >
+                        {article.description}
+                    </Typography>
+                </CardContent>
+
+                <CardActions sx={{ justifyContent: 'center' }}>
+                    <Link href={`/ideas/2023/${article.slug}`} passHref>
+                        <Button
+                            sx={{
+                                color: '#3c982c',
+                                textTransform: 'none',
+                            }}
+                            className="font-Nunito-Bold text-green-600 dark:text-yellow-400 text-lg leading-7 text-center"
+                        >
+                            Know more <ArrowForwardIcon sx={{ width: 20, height: 20 }} />
+                        </Button>
+                    </Link>
+                </CardActions>
+            </MuiCard>
+        </Grid>
+    );
+}
+
+export default function Ideas({ articles }) {
+    return (
+        <>
+            <Head>
+                <title>Idea List</title>
+                <meta name="description" content="Idea List for GSOC 2023" />
+            </Head>
+
+            <Container className="mt-20 mb-28">
+                <div className="flex justify-center items-center w-full">
+                    <p className="font-mono text-lg leading-7 text-zinc-600 dark:text-zinc-400">
+                        AOSSIE&apos;s{' '}
+                        <b>Idea List</b> for{' '}
+                        <b>Google Summer of Code 2023</b>
+                    </p>
+                </div>
+
+                <Container.Inner>
+                    <div className="mt-10 sm:mt-20 flex justify-center">
+                        <Grid container spacing={4} sx={{ justifyContent: 'center' }}>
+                            {articles.map((article) => (
+                                <Article key={article.slug} article={article} />
+                            ))}
+                        </Grid>
+                    </div>
+
+                    <div className="text-center mt-16">
+                        <Link
+                            href="/ideas"
+                            className="mx-auto group rounded-lg items-center overflow-hidden bg-zinc-800 dark:bg-white px-8 py-3 text-white focus:outline-none dark:text-black"
+                        >
+                            <span className="font-mono font-semibold">Go Back</span>
+                        </Link>
+                    </div>
+                </Container.Inner>
+            </Container>
+        </>
+    );
+}
+
+export async function getStaticProps() {
+    return {
+        props: {
+            articles: (await getAllIdeas()).map(({ component, ...meta }) => meta),
+        },
+    };
+} 

--- a/src/pages/ideas/2024/index.jsx
+++ b/src/pages/ideas/2024/index.jsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import Link from 'next/link';
 import { Container } from '@/components/Container';
-import { getAllIdeas } from '@/helper/getAllIdeas';
+import { getAllIdeas } from '@/helper/getAllIdeas2024';
 import Grid from '@mui/material/Grid';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';

--- a/src/pages/ideas/index.jsx
+++ b/src/pages/ideas/index.jsx
@@ -110,6 +110,17 @@ export default function Ideas({ articles }) {
           is your go-to destination for finding your next big project and
           kickstart your open-source journey.
         </p>
+        <div className="flex flex-wrap gap-4 justify-center my-8">
+          <Link href="/ideas/2024">
+            <button className="rounded-lg bg-zinc-800 px-6 py-2 text-white dark:bg-white dark:text-black font-mono font-semibold">2024 Ideas</button>
+          </Link>
+          <Link href="/ideas/2023">
+            <button className="rounded-lg bg-zinc-800 px-6 py-2 text-white dark:bg-white dark:text-black font-mono font-semibold">2023 Ideas</button>
+          </Link>
+          <Link href="/ideas/2022">
+            <button className="rounded-lg bg-zinc-800 px-6 py-2 text-white dark:bg-white dark:text-black font-mono font-semibold">2022 Ideas</button>
+          </Link>
+        </div>
         <Container.Inner>
           <div className="mt-10 flex justify-center sm:mt-20">
             <Grid container spacing={4} sx={{ justifyContent: 'center' }}>


### PR DESCRIPTION
## fix: Correct year-specific ideas list loading and navigation (2022-2024)

### Issue
Fixes #456 :  
**"View 2024 Ideas List" button does not update content, only changes to 'Back' button"**

---

### What was changed

- **2024 Ideas List:**  
  - `/ideas/2024` now correctly loads and displays only 2024 project ideas using the correct data source.
- **Year Navigation:**  
  - Added dedicated pages for `/ideas/2023` and `/ideas/2022`, each loading the correct year's ideas.
  - Updated navigation on the main `/ideas` page to allow users to easily switch between 2022, 2023, and 2024 ideas lists.
- **Consistency:**  
  - Each year-specific page uses its own data loader, ensuring accurate and isolated content for each year.

---
### ScreenShots:
Default:
![image](https://github.com/user-attachments/assets/70a5aa2c-5cfc-4297-a32c-b981ce248962)

Ideas 2024:
![image](https://github.com/user-attachments/assets/160a80eb-f46b-4d26-8fd8-7f7fa5985bb2)

Ideas 2023:
![image](https://github.com/user-attachments/assets/5345ffe0-97fa-4d04-9dd1-0c19d516f6a2)

Ideas 2022:
![image](https://github.com/user-attachments/assets/8926d407-265f-44ba-a914-83fc07c594b3)



**Closes:**  
#456 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated pages for Google Summer of Code ideas for 2022 and 2023, each displaying a styled, responsive grid of idea summaries with navigation to detailed pages and a "Go Back" option.
  - Introduced a button section on the main Ideas page, allowing quick navigation to idea lists for 2022, 2023, and 2024.

- **Enhancements**
  - Updated the data source for the 2024 ideas page to ensure accurate content for that year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->