### PR TITLE
Fix:link open in a new tab

### DIFF
--- a/src/pages/apply.jsx
+++ b/src/pages/apply.jsx
@@ -142,7 +142,7 @@ export default function About() {
             <div className="mt-20 relative block rounded-3xl dark:bg-white/70 bg-zinc-400/20 p-8 pb-16 shadow-xl">
               <Image src={GSoC} alt='gsoc' width={500} height={350} className="mx-auto" />
               <div className="mt-10 flex justify-center gap-6 flex-col sm:flex-row">
-                <Link className="order-1 group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-zinc-800 px-8 py-3 text-black dark:text-white focus:outline-none" href="https://summerofcode.withgoogle.com/">
+                <Link className="order-1 group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-zinc-800 px-8 py-3 text-black dark:text-white focus:outline-none" href="https://summerofcode.withgoogle.com/" target="_blank">
                   <span className="font-mono font-semibold text-center">
                     View GSoC Program Announcements
                   </span>


### PR DESCRIPTION
Add target="_blank" to link to open in new tab     

### Summary
Updated the <Link> tag to include `target="_blank"` so that the link opens in a new tab.

### Changes
- Added `target="_blank"` attribute to the link element in [apply.jsx].
- This ensures that when users click the link, the current page remains open.

### Motivation
Previously, clicking the link would navigate away from the current page, which could disrupt user experience. Opening in a new tab improves usability.

### Testing
- Clicked the updated link locally and verified it opens in a new tab.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * The “View GSoC Program Announcements” external link now opens in a new browser tab, letting you read announcements without leaving the application.
  * This helps preserve your place and progress while browsing external content.
  * No other behavior, styling, or layout changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->