### PR TITLE
Fix: Make project card links clickable by adding href attribute

### DIFF
--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -83,10 +83,14 @@ const Cards = () => {
               </Typography>
             </CardContent>
             <CardActions sx={{ justifyContent: 'center' }}>
-              <p className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
+              <a 
+                href={project.link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
                 <LinkIcon className="h-6 w-6 flex-none scale-110" />
                 <span className="ml-2">{project.link.label}</span>
-              </p>
+              </a>
             </CardActions>
           </MuiCard>
         </Grid>


### PR DESCRIPTION
This pull request fixes a minor bug where the project links in the <Cards /> component were non-functional. The link element was a paragraph tag ,I have added an anchor tag instead and it also the necessary href attribute. Changes:

Replaced with appropriate tag

Added href={project.link.href} to the anchor tag in projects.jsx.

Added target="_blank" and rel="noopener noreferrer" for external link best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project items throughout the application are now fully interactive clickable links. Selecting any project card opens its dedicated project page in a new browser tab with secure cross-origin link handling enabled. This enhancement enables smooth, uninterrupted navigation while preserving your current browsing session and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->