### PR TITLE
issue #397 has been resolved

### DIFF
--- a/src/pages/apply.jsx
+++ b/src/pages/apply.jsx
@@ -119,7 +119,7 @@ export default function About() {
                 title="Start Contributing"
                 description="Contribute to the project and make your mark on open-source development with AOSSIE. By making a Pull Request (PR) to one of our existing projects, you'll have the opportunity to showcase your skills and demonstrate your understanding of the project. This will also give you an opportunity to work with the mentors and get familiar with the project before the official GSoC coding period starts. This is a great way to get started and increase your chances of being selected for the program."
                 button="Contribute"
-                link="https://gitlab.com/aossie"
+                link="https://github.com/aossie-org"
               />
               <TimelineElement
                 title="Write a Draft Application"


### PR DESCRIPTION
Issue:  Update Gitlab link to Github redirect link

Description:
Updated the project's redirecting link from Gitlab to Github to reflect the current repository location. This change ensures users are directed to the correct and active repository.

Changes made:

Updated the redirect URL from Gitlab link to  Github link
Issue Refrence:
https://github.com/AOSSIE-Org/website/issues/397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external contribution link reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->