### PR TITLE
Fix: Make project card links clickable on /projects page

### DIFF
--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -83,10 +83,15 @@ const Cards = () => {
               </Typography>
             </CardContent>
             <CardActions sx={{ justifyContent: 'center' }}>
-              <p className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
+              <a
+                href={project.link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 dark:text-zinc-200 hover:text-[#00843D] dark:hover:text-yellow-400"
+              >
                 <LinkIcon className="h-6 w-6 flex-none scale-110" />
                 <span className="ml-2">{project.link.label}</span>
-              </p>
+              </a>
             </CardActions>
           </MuiCard>
         </Grid>


### PR DESCRIPTION
## Description

This PR fixes a bug on the `/projects` page where the project links (e.g., "Agora", "EduAid") were not clickable, preventing users from visiting the project repositories.

## The Problem

The UI was rendering the project link and icon inside a `<p>` (paragraph) tag instead of an `<a>` (anchor) tag. This displayed the text correctly but provided no click functionality, even though the correct URLs were available in the data file.

**File:** `src/pages/projects.jsx`

**Old (Broken) Code:**
```javascript
<p className="...">
  <LinkIcon ... />
  <span>{project.link.label}</span>
</p>
```

## The Solution

I have replaced the `<p>` element with a functional `<a>` tag.

* It correctly uses the `project.link.href` for the link's destination.
* It uses `target="_blank"` and `rel="noopener noreferrer"` to securely open the link in a new tab.
* The styling and icon have been preserved.

**New (Fixed) Code:**
```javascript
<a
  href={project.link.href}
  target="_blank"
  rel="noopener noreferrer"
  className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 dark:text-zinc-200 hover:text-[#00843D] dark:hover:text-yellow-400"
>
  <LinkIcon className="h-6 w-6 flex-none scale-110" />
  <span className="ml-2">{project.link.label}</span>
</a>
```

## How to Test

1.  Pull this branch.
2.  Run `npm install` (if needed) and then `npm run dev`.
3.  Navigate to the `/projects` page in your browser.
4.  Click on any of the project links (e.g., "Agora").
5.  **Verify:** The project's repository should open in a new browser tab.

## Additional Note
As mentioned in the original bug report, the "OpenChat" project has its `href` set to `"#"` in the data file. This PR fixes the UI component, but that specific project will still not lead to a valid destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project links are now fully interactive and clickable across the entire link area.
  * Links open in a new tab with security best practices.
  * Enhanced hover states in both light and dark modes provide improved visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->