### PR TITLE
feat: resolved On the Ideas page, only the bottom and the top part of…

### DIFF
--- a/src/pages/ideas/index.jsx
+++ b/src/pages/ideas/index.jsx
@@ -7,68 +7,72 @@ import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardActions from '@mui/material/CardActions';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
 function Article({ article }) {
   return (
     <Grid item xs={12} sm={6} md={4}>
-      <MuiCard
-        className="dark:bg-[#2A2A2A] dark:border-white"
-        sx={{
-          height: 350,
-          borderRadius: 2,
-          border: '1px solid',
-          borderColor: '#3c982c',
-          boxShadow: '0px 4px 4px #00000040',
-          backdropFilter: 'blur(4px) brightness(100%)',
-          display: 'flex',
-          flexDirection: 'column',
-          transition: 'background-color 0.3s ease',
-
-        }}
-      >
-        <CardContent sx={{ flexGrow: 1, textAlign: 'center' }}>
-          <Typography
-            variant="h5"
-            className="mt-6 text-2xl font-mono text-green-600 dark:text-yellow-400"
-            sx={{ fontFamily: 'Nunito-Bold', color: '#3c982c', textAlign: 'center' }}
-          >
-            {article.title}
-          </Typography>
-
-          <Typography
-            variant="body1"
-            className="text-zinc-600 text-base dark:text-zinc-400 text-lg font-mono leading-6 text-center"
+      <Link href={`/ideas/2025/${article.slug}`} passHref legacyBehavior>
+        <a
+          className="block h-full text-decoration-none"
+          aria-label={`Read more about ${article.title}`}
+        >
+          <MuiCard
+            className="dark:bg-[#2A2A2A] dark:border-white hover:shadow-lg"
             sx={{
-              fontFamily: 'Nunito-Light',
-              color: 'black',
-              mt: 2,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              display: '-webkit-box',
-              WebkitBoxOrient: 'vertical',
-              WebkitLineClamp: 4,
+              height: 350,
+              borderRadius: 2,
+              border: '1px solid',
+              borderColor: '#3c982c',
+              boxShadow: '0px 4px 4px #00000040',
+              backdropFilter: 'blur(4px) brightness(100%)',
+              display: 'flex',
+              flexDirection: 'column',
+              transition: 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+              cursor: 'pointer',
+              '&:hover': {
+                transform: 'translateY(-8px)',
+                boxShadow: '0px 20px 40px rgba(60, 152, 44, 0.3), 0px 0px 0px 3px rgba(60, 152, 44, 0.4)',
+                borderColor: '#00843D',
+                borderWidth: '2px',
+              },
             }}
           >
-            {article.description}
-          </Typography>
-        </CardContent>
+            <CardContent sx={{ flexGrow: 1, textAlign: 'center' }}>
+              <Typography
+                variant="h5"
+                className="mt-6 text-2xl font-mono text-green-600 dark:text-yellow-400"
+                sx={{ fontFamily: 'Nunito-Bold', color: '#3c982c', textAlign: 'center' }}
+              >
+                {article.title}
+              </Typography>
 
-        <CardActions sx={{ justifyContent: 'center' }}>
-          <Link href={`/ideas/2025/${article.slug}`} passHref>
-            <Button
-              sx={{
-                color: '#3c982c',
-                textTransform: 'none', // Prevent uppercase
-              }}
-              className="font-Nunito-Bold text-green-600 dark:text-yellow-400 text-lg leading-7 text-center"
-            >
-              Know more <ArrowForwardIcon sx={{ width: 20, height: 20 }} />
-            </Button>
-          </Link>
-        </CardActions>
-      </MuiCard>
+              <Typography
+                variant="body1"
+                className="text-zinc-600 text-base dark:text-zinc-400 text-lg font-mono leading-6 text-center"
+                sx={{
+                  fontFamily: 'Nunito-Light',
+                  color: 'black',
+                  mt: 2,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  display: '-webkit-box',
+                  WebkitBoxOrient: 'vertical',
+                  WebkitLineClamp: 4,
+                }}
+              >
+                {article.description}
+              </Typography>
+            </CardContent>
+
+            <CardActions sx={{ justifyContent: 'center' }}>
+              <span className="flex items-center text-md font-semibold font-mono text-green-600 dark:text-yellow-400">
+                Know more <ArrowForwardIcon sx={{ width: 20, height: 20, marginLeft: '8px' }} />
+              </span>
+            </CardActions>
+          </MuiCard>
+        </a>
+      </Link>
     </Grid>
   );
 }
@@ -85,7 +89,7 @@ export default function Ideas({ articles }) {
         <div className="ideas-text flex items-center justify-center mb-8 relative">
           <div
             className="hidden md:block w-[75px] h-[75px] m-2 bg-cover bg-center dark:bg-[url('/logo.png')] bg-[url('/logo.png')] absolute left-10"
-            alt="GSOC Logo"
+            aria-label="GSOC Logo"
           ></div>
 
 


### PR DESCRIPTION
 Resolved : the idea card is clickable, while the entire card should be clickable in the ideas section #74 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Article cards on the Ideas page are now fully clickable, making navigation more intuitive
  * Added visual hover effects including shadow elevation and styling changes

* **Improvements**
  * Enhanced accessibility with improved labeling
  * Navigation redesigned as a "Know more" link with arrow indicators for clearer intent

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->