### PR TITLE
Remove Duplicate Navbar from Footer Section (Fixes #105)

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,17 +5,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
 import { faDiscord, faGithub, faGitlab, faTwitter } from '@fortawesome/free-brands-svg-icons'
 
-function NavLink({ href, children }) {
-  return (
-    <Link
-      href={href}
-      className="transition hover:text-[#00843D] dark:hover:text-yellow-400"
-    >
-      {children}
-    </Link>
-  )
-}
-
 export function Footer() {
   return (
     <footer className="mt-16">
@@ -23,12 +12,6 @@ export function Footer() {
         <div className="pt-10 pb-10">
           <Container.Inner>
             <div className="flex flex-col items-center justify-between gap-6 sm:flex-row">
-              <div className="flex gap-5 text-md font-semibold font-mono text-zinc-800 dark:text-zinc-200">
-                <NavLink href="/about">About</NavLink>
-                <NavLink href="/projects">Projects</NavLink>
-                <NavLink href="/ideas">Ideas</NavLink>
-                <NavLink href="/apply">Apply</NavLink>
-              </div>
               <p className="text-sm text-zinc-400 dark:text-zinc-500 font-mono">
                 &copy; 2016-2025 AOSSIE. All rights reserved.
               </p>


### PR DESCRIPTION
This pull request addresses issue #105 by removing the redundant navigation bar from the footer section. The navbar now only appears in the header, following standard web design practices and improving user experience.

Changes made:
  - Removed the navbar from the footer section.
  - Ensured the header navbar remains consistent and fully functional.

Screenshots:
  - Before: 
<img width="1093" height="149" alt="Before" src="https://github.com/user-attachments/assets/77b1e0b7-844d-41e8-b7dc-0461a743fa6e" />

  - After: 
<img width="1102" height="150" alt="After" src="https://github.com/user-attachments/assets/121cc38b-a9d8-4027-9d0c-39dbf3d3b183" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified footer layout by removing the navigation section containing links to About, Projects, Ideas, and Apply. The footer now displays exclusively copyright information and social/contact icons, creating a cleaner design while preserving branding and contact accessibility for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->