### PR TITLE
fix: Make project links clickable and open in new tab (Fixes #441)

### DIFF
--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -83,10 +83,16 @@ const Cards = () => {
               </Typography>
             </CardContent>
             <CardActions sx={{ justifyContent: 'center' }}>
-              <p className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
+              <a
+                href={project.link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition hover:text-[#00843D] dark:hover:text-yellow-400 dark:text-zinc-200 items-center"
+                style={{ textDecoration: 'none' }}
+              >
                 <LinkIcon className="h-6 w-6 flex-none scale-110" />
                 <span className="ml-2">{project.link.label}</span>
-              </p>
+              </a>
             </CardActions>
           </MuiCard>
         </Grid>


### PR DESCRIPTION
Overview

  - This PR fixes the issue where project links on the Projects page were not clickable and did not direct users to the correct external repositories.

Details

- Updated the project cards to use an anchor tag for each project link.
- Links now open in a new tab (target="_blank") and use (rel="noopener noreferrer") for security.
- Improved accessibility and user experience for navigating to project repositories.

Related Issue
Closes #433 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project links are now properly clickable with enhanced functionality. Links open in new browser tabs and include improved styling with hover effects and dark mode support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->