### PR TITLE
fix(projects): make project card links clickable (fix #433)

### DIFF
--- a/src/components/CardEffect.jsx
+++ b/src/components/CardEffect.jsx
@@ -1,8 +1,9 @@
 import Image from 'next/image'
+import Link from 'next/link'
 
-export function CardEffect({heading, content, logo}) {
+export function CardEffect({heading, content, logo, href}) {
     return (
-        <a className="group relative block h-[22rem] max-lg:w-72 max-xl:w-60 w-72 cursor-pointer">
+        <Link href={href || '#'} target="_blank" rel="noopener noreferrer" className="group relative block h-[22rem] max-lg:w-72 max-xl:w-60 w-72 cursor-pointer">
             {/* <span className="absolute inset-0 border-2 rounded-lg border-dashed border-black dark:border-zinc-300"></span> */}
 
             {/* <div className="relative flex h-full transform items-end border-4 rounded-lg border-black dark:border-zinc-300 bg-transparent dark:bg-transparent transition-transform group-hover:-translate-x-2 group-hover:-translate-y-2"> */}
@@ -22,6 +23,6 @@ export function CardEffect({heading, content, logo}) {
                     <p className="mt-4 font-mono sm:w-100 w-52">{content}</p>
                 </div>
             </div>
-        </a>
+        </Link>
     )
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -179,6 +179,7 @@ export default function Home() {
                       heading={project.name}
                       logo={project.logo}
                       content={project.description}
+                      href={project.link.href}
                     />
                   </span>
                 ))}

--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Link from 'next/link';
 import Grid from '@mui/material/Grid';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -83,10 +84,10 @@ const Cards = () => {
               </Typography>
             </CardContent>
             <CardActions sx={{ justifyContent: 'center' }}>
-              <p className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
+              <Link href={project.link.href} target="_blank" rel="noopener noreferrer" className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition hover:text-[#00843D] dark:hover:text-yellow-400 dark:text-zinc-200">
                 <LinkIcon className="h-6 w-6 flex-none scale-110" />
                 <span className="ml-2">{project.link.label}</span>
-              </p>
+              </Link>
             </CardActions>
           </MuiCard>
         </Grid>


### PR DESCRIPTION
Summary: Fixed broken project card links by wrapping link text in Next.js [Link](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) components with proper [href](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) attributes.

What I changed:

[projects.jsx](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — imported [Link](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and wrapped the project link display in a clickable link element that opens in a new tab.
[CardEffect.jsx](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — replaced the non-functional <a> tag with [<Link>](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and added an [href](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prop to make the entire card clickable.
[index.jsx](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — passed [project.link.href](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prop to [CardEffect](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so the home page project cards are also clickable.
Why: The project cards were displaying link text but were not wrapped in clickable elements. Clicking on them did nothing because there was no [href](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) attribute or Next.js [Link](vscode-file://vscode-app/c:/Users/samee/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project cards are now clickable and navigate to their respective links
  * External links now open in new tabs with enhanced security protections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->