### PR TITLE
Fix: Overlapping cards on tablet screen sizes (640px–715px)

### DIFF
--- a/src/components/CardEffect.jsx
+++ b/src/components/CardEffect.jsx
@@ -2,8 +2,7 @@ import Image from 'next/image'
 
 export function CardEffect({heading, content, logo}) {
     return (
-        <a className="group relative block h-auto sm:w-72 md:w-full lg:w-72 cursor-pointer">
-
+        <a className="group relative block h-[22rem] max-lg:w-72 max-xl:w-60 w-72 cursor-pointer">
             {/* <span className="absolute inset-0 border-2 rounded-lg border-dashed border-black dark:border-zinc-300"></span> */}
 
             {/* <div className="relative flex h-full transform items-end border-4 rounded-lg border-black dark:border-zinc-300 bg-transparent dark:bg-transparent transition-transform group-hover:-translate-x-2 group-hover:-translate-y-2"> */}
@@ -19,11 +18,8 @@ export function CardEffect({heading, content, logo}) {
                     />
                     <h2 className="ml-0 leading-9 text-4xl text-center flex font-extrabold justify-center font-mono text-[#00843D] dark:text-yellow-400">{heading}</h2>
                 </div>
-                <div className=" md:relative 
-                md:opacity-100 
-                lg:absolute lg:opacity-0 lg:group-hover:relative lg:group-hover:opacity-100
-                self-center pr-6 transition-opacity dark:text-zinc-300">
-                    <p className="mt-4 font-mono w-full sm:max-w-sm">{content}</p>
+                <div className="absolute self-center pr-6 lg:scale-90 lg:pb-0 lg:pl-3 lg:pr-0 xl:pl-0 md:p-0 md:scale-95 opacity-0 transition-opacity group-hover:relative group-hover:opacity-100 dark:text-zinc-300">
+                    <p className="mt-4 font-mono sm:w-100 w-52">{content}</p>
                 </div>
             </div>
         </a>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -172,7 +172,7 @@ export default function Home() {
           </div>
           <div className="mt-10 flex flex-col items-center gap-6 sm:flex-row sm:justify-evenly sm:gap-0">
             <Container.Inner>
-              <div className="grid grid-cols-1 gap-x-12 gap-y-16 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid grid-cols-1 gap-x-12 gap-y-16 md:grid-cols-2 lg:grid-cols-3">
                 {randomProjects.map((project) => (
                   <span key={project.name}>
                     <CardEffect


### PR DESCRIPTION
Fixes #21

This PR fixes a layout issue where project cards overlapped on
tablet screen sizes (640px–715px) by adjusting the grid breakpoint.
Desktop and mobile behavior remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Projects section grid layout breakpoints to display as a single column on smaller screens and transition to a two-column layout on medium screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->