### PR TITLE
Fix hero section text overlap on small and medium screens

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -5,10 +5,10 @@ import { Pattern } from '@/components/Pattern';
 export function Banner() {
   return (
     <section aria-label="Apply Banner" className="scroll-mt-14 bg-[#00843D] dark:bg-yellow-400 sm:scroll-mt-32">
-      <div className="overflow-hidden lg:relative">
+      <div className="relative overflow-hidden">
         <ContainerPattern size="md" className="relative grid grid-cols-1 items-end gap-y-12 lg:static lg:grid-cols-2 pt-24 pb-8 sm:py-10">
-          <Pattern className="absolute -top-28 left-0 w-full sm:left-3/4 sm:-top-10 sm:ml-8 sm:w-auto md:left-2/3 lg:left-auto lg:right-2 lg:ml-0 xl:right-auto xl:left-2/3" />
-          <Pattern className="absolute mt-2 -top-32 left-0 w-full sm:left-3/4 sm:top-36 sm:ml-8 sm:w-auto md:left-2/3 lg:left-auto lg:right-2 lg:ml-0 xl:right-auto xl:left-2/3 sm:visible invisible" />
+          <Pattern className="absolute hidden lg:block -top-28 left-0 w-full max-w-full sm:left-3/4 sm:-top-10 sm:ml-8 sm:w-auto md:left-2/3 lg:left-auto lg:right-2 lg:ml-0 xl:right-auto xl:left-2/3" />
+          <Pattern className="absolute hidden lg:block mt-2 -top-32 left-0 w-full max-w-full sm:left-3/4 sm:top-36 sm:ml-8 sm:w-auto md:left-2/3 lg:left-auto lg:right-2 lg:ml-0 xl:right-auto xl:left-2/3" />
           <div>
             <h2 className="font-mono text-5xl font-black tracking-tighter text-white dark:text-black sm:w-3/4 sm:text-5xl md:w-2/3 lg:w-auto">
               Launch into AOSSIE&apos;s open-source world through GSoC!


### PR DESCRIPTION
Fixes #522

### Summary
This PR fixes an issue where the decorative hero pattern overlaps the text on small and medium screen sizes, affecting readability.

The pattern is hidden below the `lg` breakpoint to prevent overlap and layout issues, while preserving the existing desktop layout.

### Details
- Prevents decorative SVG patterns from overlapping hero content on `sm` and `md` breakpoints
- Ensures clean, readable layout on smaller screens
- Keeps the original design intact for large screens

### Notes
A future enhancement could explore repositioning the pattern on tablet-sized screens instead of hiding it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive design of the banner with optimized visibility of decorative elements across different screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->