### PR TITLE
fixed the project link not working issue

### DIFF
--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -83,10 +83,12 @@ const Cards = () => {
               </Typography>
             </CardContent>
             <CardActions sx={{ justifyContent: 'center' }}>
-              <p className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
-                <LinkIcon className="h-6 w-6 flex-none scale-110" />
-                <a href={project.link.href}><span className="ml-2">{project.link.label}</span></a>
-              </p>
+              <a href={project.link.href} rel="noopener noreferrer">
+                <p className="relative z-10 mt-6 flex text-md font-semibold font-mono text-zinc-600 transition group-hover:text-[#00843D] dark:group-hover:text-yellow-400 dark:text-zinc-200">
+                  <LinkIcon className="h-6 w-6 flex-none scale-110" />
+                  <span className='ml-2'>{project.link.label}</span>  
+                </p>
+              </a>
             </CardActions>
           </MuiCard>
         </Grid>


### PR DESCRIPTION
This PR adds an anchor (<a>) tag to redirect users to the projects page.

issue: #524 

### demo video
https://github.com/user-attachments/assets/aefa95b8-601c-41fa-be6c-4ace9f9f0968

### what changes made 
just wrapped span tag here in an  _<a href={project.link.href}>_  and done👍
<img width="753" height="137" alt="image" src="https://github.com/user-attachments/assets/761cb89f-5730-471c-9fe1-d53c0740b3fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project links in project cards so the entire card area is clickable and navigates to the intended destination, preserving appearance and improving navigation/usability.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->