### PR TITLE
Fixed footer year to be dynamic

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -30,7 +30,7 @@ export function Footer() {
                 <NavLink href="/apply">Apply</NavLink>
               </div>
               <p className="text-sm text-zinc-400 dark:text-zinc-500 font-mono">
-                &copy; 2016-2025 AOSSIE. All rights reserved.
+                &copy; 2016-{new Date().getFullYear()} AOSSIE. All rights reserved.
               </p>
               <div className="flex gap-6">
                 <Link aria-label="Contact by Mail" className=' text-zinc-400 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com'>


### PR DESCRIPTION
### Summary
Updated the footer to use a dynamic year instead of a hardcoded value.

### Why
The footer year had become outdated. Making it dynamic ensures it stays
up to date automatically without requiring manual changes.

If a static year is preferred, I’m happy to update it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated footer copyright year to dynamically reflect the current year instead of displaying a fixed year.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->