### PR TITLE
fix: resolve hero section horizontal overflow on medium screens (640p…

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -5,11 +5,22 @@ import { Pattern } from '@/components/Pattern';
 export function Banner() {
   return (
     <section aria-label="Apply Banner" className="scroll-mt-14 bg-[#00843D] dark:bg-yellow-400 sm:scroll-mt-32">
-      <div className="overflow-hidden lg:relative">
+      <div className="relative overflow-hidden">
         <ContainerPattern size="md" className="relative grid grid-cols-1 items-end gap-y-12 lg:static lg:grid-cols-2 pt-24 pb-8 sm:py-10">
-          <Pattern className="absolute -top-28 left-0 w-full sm:left-3/4 sm:-top-10 sm:ml-8 sm:w-auto md:left-2/3 lg:left-auto lg:right-2 lg:ml-0 xl:right-auto xl:left-2/3" />
-          <Pattern className="absolute mt-2 -top-32 left-0 w-full sm:left-3/4 sm:top-36 sm:ml-8 sm:w-auto md:left-2/3 lg:left-auto lg:right-2 lg:ml-0 xl:right-auto xl:left-2/3 sm:visible invisible" />
-          <div>
+          
+          {/* Add gradient mask that fades to right */}
+          <div 
+            className="absolute inset-0 overflow-hidden pointer-events-none"
+            style={{
+              maskImage: 'linear-gradient(to right, transparent 0%, black 20%, black 60%, transparent 100%)',
+              WebkitMaskImage: 'linear-gradient(to right, transparent 0%, black 20%, black 60%, transparent 100%)'
+            }}
+          >
+            <Pattern className="absolute -top-28 left-0 w-full sm:left-3/4 sm:-top-10 sm:ml-8 sm:w-auto md:left-2/3 lg:left-auto lg:right-2 lg:ml-0 xl:right-auto xl:left-2/3" />
+            <Pattern className="absolute mt-2 -top-32 left-0 w-full sm:left-3/4 sm:top-36 sm:ml-8 sm:w-auto md:left-2/3 lg:left-auto lg:right-2 lg:ml-0 xl:right-auto xl:left-2/3 sm:visible invisible" />
+          </div>
+
+          <div className="relative z-10">
             <h2 className="font-mono text-5xl font-black tracking-tighter text-white dark:text-black sm:w-3/4 sm:text-5xl md:w-2/3 lg:w-auto">
               Launch into AOSSIE&apos;s open-source world through GSoC!
             </h2>


### PR DESCRIPTION


- Added overflow-hidden to Banner component container
- Wrapped Pattern components in constrained container with gradient mask
- Applied CSS gradient mask for smooth fade effect on patterns that looks much better
- Ensures no horizontal scroll between 640px-1024px viewports

Fixes #522
<img width="606" height="417" alt="image" src="https://github.com/user-attachments/assets/2a046811-c018-44c2-b129-4dd8eb60e79b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Refined banner visual hierarchy with improved element layering and stacking order.
* Added gradient fade effect to decorative overlay elements for enhanced visual depth and improved content contrast.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->