### PR TITLE
chore: update browserslist db to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2444,9 +2444,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001699",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
-      "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
+      "version": "1.0.30001766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
+      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
Updated outdated dependencies to fix terminal warning.

Updated the outdated `caniuse-lite` database to fix the terminal warning during `npm run dev`.

Ran `npx update-browserslist-db@latest` to apply the fix.