### PR TITLE
Fix hero description text overlap on medium screens

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -35,7 +35,7 @@ export default function Home() {
           {/* Background Image */}
           <div
             className=" absolute  right-0 top-[-230px] z-0 mb-20 hidden h-[600px] w-full bg-[url('../images/background.png')] bg-cover bg-center dark:bg-[url('../images/background-dark.png')]
- md:block md:h-[800px] lg:h-[650]"
+ md:block md:h-[800px] lg:h-[800px]"
           ></div>
 
           {/* Main Content */}


### PR DESCRIPTION
### What was fixed
The hero section description text was overlapping with the yellow decorative background at medium screen widths, reducing readability.

### Cause
The decorative background is absolutely positioned, and at the `md` breakpoint the text container did not have sufficient spacing to avoid overlap.


https://github.com/user-attachments/assets/541fac6f-501f-48a4-afec-11fc10be91b6



### Related issue
Fixes #544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined layout, spacing, and responsive behavior across the hero, background image, main content, and project grid.
  * Updated logo alignment, heading typography, paragraph wrapping, and small spacing tweaks for icons and CTA.
  * Removed the final banner from the page.

* **Refactor**
  * Reorganized container and content ordering to improve visual flow and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->