### PR TITLE
fix:button(Learn More About Us)-flickering-on-hover-fixed

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -97,17 +97,19 @@ export default function Home() {
                 </div>
                 <div className="mt-12 mx-4 md:mx-0 md:mt-8 text-left ">
                   <Link href="/about" className="group relative inline-block text-lg">
-                    <span className="relative z-10 block overflow-hidden rounded-lg border-2 border-gray-900 px-5 py-3 transition-colors duration-300 ease-in-out group-hover:text-white dark:group-hover:text-black">
+                    <span className="relative z-10 block overflow-hidden rounded-lg border-2 border-gray-900  px-5 py-3 transition-colors duration-300 ease-in-out group-hover:text-white dark:group-hover:text-black">
                       <span className="absolute inset-0 h-full w-full rounded-lg bg-white px-5 py-3"></span>
                       <span className="absolute left-0 -ml-2 h-48 w-72 origin-top-right -translate-x-full translate-y-12 -rotate-90 bg-[#00843D] transition-all duration-300 ease-in-out group-hover:-rotate-180 dark:bg-yellow-400"></span>
                       <span className="relative font-mono text-xl font-black tracking-tighter">
                         Learn More About Us
                       </span>
                     </span>
+
                     <span
-                      className="absolute bottom-0 right-0 mb-3 mr-2 h-14 w-full rounded-lg bg-[#00843D] transition-all duration-200 ease-linear group-hover:m-0 dark:bg-yellow-400"
+                      className="absolute pointer-events-none bottom-0 right-0 mb-3 mr-2 h-14 w-full rounded-lg bg-[#00843D]  transition-all duration-200 ease-linear group-hover:m-0  dark:bg-yellow-400"
                       data-rounded="rounded-lg"
                     ></span>
+
                   </Link>
                 </div>
               </div>


### PR DESCRIPTION
This is a simple one word fix to the problem that was causing button flickering as expected when the mouse pointer is on the edge as well demonstrated in the issue #572 by simply the property (pointer-event-none) to make the second span(dark green span) unresponsive to any mouse pointer events like hover etc. 

If this is the desired outcome then I think this is the correct fix. If the intent is to make the second span hoverable but be unresponsive during hovering state then the fix can be different.


Fixes #572 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction behavior of the "Learn More About Us" button to prevent unintended interactions with decorative elements, ensuring more intuitive user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->