### PR TITLE
solve the statistics count of active project and contributors

### DIFF
--- a/src/config/orgStats.ts
+++ b/src/config/orgStats.ts
@@ -1,0 +1,5 @@
+export const orgStats = {
+  activeProjects: 34,
+  totalContributors: 500,
+  communityCount: 3800,
+};

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { orgStats } from '../config/orgStats';
 import Image from 'next/image';
 import Head from 'next/head';
 import { Container } from '@/components/Container';
@@ -154,15 +155,15 @@ export default function About() {
         </p>
         <div style={styles.stats}>
           <div className="text-green-600 dark:text-zinc-400 text-lg font-mono leading-7 font-bold">
-            <h2 style={styles.statNumber}>34+</h2>
+            <h2 style={styles.statNumber}>{orgStats.activeProjects}+</h2>
             <p style={styles.statLabel}>Active Projects</p>
           </div>
           <div className="text-green-600 dark:text-zinc-400 text-lg font-mono leading-7 font-bold">
-            <h2 style={styles.statNumber}>500+</h2>
+            <h2 style={styles.statNumber}>{orgStats.totalContributors}+</h2>
             <p style={styles.statLabel}>Total Contributors</p>
           </div>
           <div className="text-green-600 dark:text-zinc-400 text-lg font-mono leading-7 font-bold">
-            <h2 style={styles.statNumber}>3800+</h2>
+            <h2 style={styles.statNumber}>{orgStats.communityCount}+</h2>
             <p style={styles.statLabel}>Community Count</p>
           </div>
         </div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import { orgStats } from '../config/orgStats'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useState, useEffect } from 'react'
@@ -126,15 +127,15 @@ export default function Home() {
           <div className="hidden bg-[#3C982C] relative dark:text-black sm:flex flex-col md:flex-row justify-between p-4 sm:p-8 px-4 sm:px-16 text-center border border-white text-white dark:bg-yellow-400 z-20">
             <div className="mb-4 sm:mb-0">
               <h6 className="text-xl">Active Projects</h6>
-              <p className="font-semibold text-2xl">34+</p>
+              <p className="font-semibold text-2xl">{orgStats.activeProjects}+</p>
             </div>
             <div className="mb-4 sm:mb-0">
               <h6 className="text-xl">Total Contributors</h6>
-              <p className="font-semibold text-2xl">500+</p>
+              <p className="font-semibold text-2xl">{orgStats.totalContributors}+</p>
             </div>
             <div className="mb-4 sm:mb-0">
               <h6 className="text-xl">Community Count</h6>
-              <p className="font-semibold text-2xl">2000+</p>
+              <p className="font-semibold text-2xl">{orgStats.communityCount}+</p>
             </div>
           </div>
 


### PR DESCRIPTION
Addressed Issues:
Centralize and synchronize organization stats
Fixes #575 

previous -
<img width="863" height="995" alt="Screenshot 2026-02-25 041247" src="https://github.com/user-attachments/assets/21229958-ce32-460e-af66-06a5c4069cca" />

 After chnage-
<img width="1547" height="607" alt="Screenshot 2026-02-25 040752" src="https://github.com/user-attachments/assets/2e6e7bc3-c0cd-4d9c-a756-94d13c78c472" />
align with
<img width="1698" height="682" alt="Screenshot 2026-02-25 041154" src="https://github.com/user-attachments/assets/94d3c352-5e2e-4082-bf84-a0ea2d71326b" />


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [ x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [ x] My code follows the project's code style and conventions
- [ x] My changes generate no new warnings or errors
- [x ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x ] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.

## AI Usage Disclosure

Check one of the checkboxes below:

- [ x] This PR does not contain AI-generated code at all.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Organization metrics (active projects, contributors, community count) are now sourced from a centralized configuration file and dynamically displayed across home and about pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->