### PR TITLE
fix: redirect contribute button to GitHub instead of GitLab

### DIFF
--- a/src/pages/apply.jsx
+++ b/src/pages/apply.jsx
@@ -119,7 +119,7 @@ export default function About() {
                 title="Start Contributing"
                 description="Contribute to the project and make your mark on open-source development with AOSSIE. By making a Pull Request (PR) to one of our existing projects, you'll have the opportunity to showcase your skills and demonstrate your understanding of the project. This will also give you an opportunity to work with the mentors and get familiar with the project before the official GSoC coding period starts. This is a great way to get started and increase your chances of being selected for the program."
                 button="Contribute"
-                link="https://gitlab.com/aossie"
+                link="https://github.com/AOSSIE-Org"
               />
               <TimelineElement
                 title="Write a Draft Application"


### PR DESCRIPTION
## Summary
Changed the contribute button link from GitLab (https://gitlab.com/aossie) to GitHub (https://github.com/AOSSIE-Org) as requested in issue #600.

## Changes
- Updated `src/pages/apply.jsx` line 122: changed link from `https://gitlab.com/aossie` to `https://github.com/AOSSIE-Org`

Closes #600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Start Contributing" link to point to GitHub instead of GitLab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->