### PR TITLE
fix: add target blank and rel noopener to external footer links

### DIFF
--- a/src/components/shared/Footer.jsx
+++ b/src/components/shared/Footer.jsx
@@ -59,19 +59,19 @@ export function Footer() {
                   <Link aria-label="Contact by Mail" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='mailto:aossie.oss@gmail.com'>
                     <FontAwesomeIcon icon={faEnvelope} size='xl' />
                   </Link>
-                  <Link aria-label="Follow on GitHub" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org'>
+                  <Link aria-label="Follow on GitHub" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://github.com/AOSSIE-Org' target="_blank" rel="noopener noreferrer">
                     <FontAwesomeIcon icon={faGithub} size='xl' />
                   </Link>
-                  <Link aria-label="Join on Discord" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.gg/hjUhu33uAn'>
+                  <Link aria-label="Join on Discord" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://discord.gg/hjUhu33uAn' target="_blank" rel="noopener noreferrer">
                     <FontAwesomeIcon icon={faDiscord} size='xl' />
                   </Link>
-                  <Link aria-label="Follow on LinkedIn" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://www.linkedin.com/company/aossie/'>
+                  <Link aria-label="Follow on LinkedIn" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://www.linkedin.com/company/aossie/' target="_blank" rel="noopener noreferrer">
                     <FontAwesomeIcon icon={faLinkedin} size='xl' />
                   </Link>
-                  <Link aria-label="Follow on X (Twitter)" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://x.com/aossie_org'>
+                  <Link aria-label="Follow on X (Twitter)" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://x.com/aossie_org' target="_blank" rel="noopener noreferrer">
                     <FontAwesomeIcon icon={faXTwitter} size='xl' />
                   </Link>
-                  <Link aria-label="Subscribe on YouTube" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://www.youtube.com/@AOSSIE-Org'>
+                  <Link aria-label="Subscribe on YouTube" className='text-zinc-500 hover:text-[#00843D] dark:text-zinc-400 dark:hover:text-yellow-400 transition' href='https://www.youtube.com/@AOSSIE-Org' target="_blank" rel="noopener noreferrer">
                     <FontAwesomeIcon icon={faYoutube} size='xl' />
                   </Link>
                 </div>


### PR DESCRIPTION
###  Addressed Issues:

Fixes #630 

###  Screenshots/Recordings:

*Note to reviewer: This is a behavior change (links opening in a new tab) rather than a visual UI change.*

**Before:** Clicking social links in the footer navigated the current tab away from the AOSSIE website.
**After:** Clicking external social links (GitHub, Discord, LinkedIn, X, YouTube) now correctly opens them in a new browser tab. 


###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->
- Added `target="_blank"` and `rel="noopener noreferrer"` to all external social media links in the `Footer.jsx` component. This ensures users are not navigated away from the AOSSIE website when clicking on external platforms.
- **Note:** I deliberately omitted `target="_blank"` from the `mailto:` link. This is a web accessibility best practice to prevent the browser from opening an empty tab before launching the user's default email client.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External social media links in the footer now open in a new browser tab with enhanced security attributes to protect against potential vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->