### PR TITLE
fix: add pointer cursor to GSoC apply button for better UX

### DIFF
--- a/src/components/shared/Banner.jsx
+++ b/src/components/shared/Banner.jsx
@@ -54,7 +54,7 @@ export function Banner() {
             </motion.p>
             <motion.div variants={{ hidden: { opacity: 0, y: 20 }, visible: { opacity: 1, y: 0 } }} className="mt-5">
               <Link href="/apply" legacyBehavior>
-                <motion.a whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} className="group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
+                <motion.a whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} className="cursor-pointer group relative rounded-lg inline-flex items-center overflow-hidden bg-white dark:bg-black px-8 py-3 text-black dark:text-white focus:outline-none font-mono font-semibold">
                   Apply for a GSoC spot with AOSSIE
                 </motion.a>
               </Link>


### PR DESCRIPTION
### Addressed Issues:

Fixes #683


### Screenshots/Recordings:

#### Before

https://github.com/user-attachments/assets/144c15c9-e41b-4408-8c6b-6032e0c6bef2

#### After

https://github.com/user-attachments/assets/e00ae52a-c0f0-4c78-b901-d40a61e84734


### Additional Notes:
This PR fixes a UI/UX inconsistency where the "Apply for a GSoC spot with AOSSIE" button did not display the expected pointer cursor on hover. The change ensures better user interaction feedback without affecting any other styles or functionality.

### AI Usage Disclosure:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: None


## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved cursor behavior on the Apply button to better indicate clickability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->