### PR TITLE
fix: replace placeholder link for OpenChat with valid internal route

### DIFF
--- a/src/helper/projects.js
+++ b/src/helper/projects.js
@@ -318,7 +318,7 @@ const projects = [
   name: 'OpenChat',
     description:
       'a decentralised platform for secure and private messaging and file sharing built on top of blockchain',
-    link: { href: '#', label: 'OpenChat' },
+    link: { href: '/projects/openchat', label: 'OpenChat' },
     logo: OpenChatLogo,
     status: 'ongoing',
     category: 'Ongoing'


### PR DESCRIPTION
###  Addressed Issues:

Fixes #680 

## Description

This PR replaces the placeholder link (`#`) in the OpenChat project entry with a valid internal route.

Previously, the OpenChat entry used a placeholder link, which resulted in non-functional navigation and inconsistent behavior compared to other project entries.

This change ensures that the project now points to a meaningful route and maintains consistency across the project list.

###  Screenshots/Recordings:

No UI changes. This PR updates project metadata to ensure proper navigation.

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the OpenChat project link to properly navigate to its dedicated project page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->