### PR TITLE
feat: add real-time project search and filtering functionality

### DIFF
--- a/src/app/projects/page.jsx
+++ b/src/app/projects/page.jsx
@@ -221,11 +221,16 @@ export default function Projects() {
             {/* Search Bar */}
             <div className="mt-8 mb-12 flex justify-center">
               <div className="relative w-full max-w-xl group">
+                <label htmlFor="project-search" className="sr-only">
+                  Search projects by name
+                </label>
                 <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none z-10">
                   <FontAwesomeIcon icon={faSearch} className="h-4 w-4 text-zinc-400 group-focus-within:text-[#00843D] dark:group-focus-within:text-yellow-400 transition-colors duration-300" />
                 </div>
                 <input
-                  type="text"
+                  id="project-search"
+                  type="search"
+                  aria-describedby="project-search-status"
                   className="block w-full pl-11 pr-4 py-3.5 border border-zinc-200 dark:border-zinc-700/50 rounded-2xl leading-5 bg-zinc-50/50 dark:bg-zinc-800/50 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-[#00843D] dark:focus:ring-yellow-400/50 focus:border-transparent sm:text-sm transition-all duration-300 shadow-sm hover:shadow-md backdrop-blur-sm"
                   placeholder="Search for projects..."
                   value={searchQuery}
@@ -233,6 +238,11 @@ export default function Projects() {
                 />
               </div>
             </div>
+            <p id="project-search-status" className="sr-only" aria-live="polite">
+              {filteredProjects.length === 0
+                ? `No projects found matching ${searchQuery.trim()}.`
+                : `${filteredProjects.length} project${filteredProjects.length === 1 ? '' : 's'} shown.`}
+            </p>
           </div>
 
           <div className="mb-16 grid grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-3">

--- a/src/app/projects/page.jsx
+++ b/src/app/projects/page.jsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState, useMemo } from 'react'
 import Link from 'next/link'
 import Grid from '@mui/material/Grid'
 import MuiCard from '@mui/material/Card'
@@ -15,7 +16,8 @@ import projects from '@/helper/projects'
 import { CardProduct } from '@/components/products/CardProduct'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons'
-import { motion } from 'framer-motion'
+import { faSearch } from '@fortawesome/free-solid-svg-icons'
+import { motion, AnimatePresence } from 'framer-motion'
 
 function LinkIcon(props) {
   return (
@@ -168,6 +170,8 @@ const styles = {
 }
 
 export default function Projects() {
+  const [searchQuery, setSearchQuery] = useState('')
+
   const readyToDownload = projects.filter(
     (p) => p.category === 'Ready to download'
   )
@@ -176,9 +180,20 @@ export default function Projects() {
   )
   const ongoing = projects.filter((p) => p.category === 'Ongoing')
 
-  const sortedProjects = [...projects].sort((a, b) =>
-    (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' })
-  )
+  const sortedProjects = useMemo(() => {
+    return [...projects].sort((a, b) =>
+      (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' })
+    )
+  }, [])
+
+  const filteredProjects = useMemo(() => {
+    const query = searchQuery.toLowerCase().trim()
+    if (!query) return sortedProjects
+
+    return sortedProjects.filter((project) =>
+      (project.name || '').toLowerCase().includes(query)
+    )
+  }, [searchQuery, sortedProjects])
 
   return (
     <>
@@ -202,12 +217,46 @@ export default function Projects() {
                 Free, open-source, and built by a global community of developers, designers, researchers, and innovators.
               </p>
             </motion.div>
+
+            {/* Search Bar */}
+            <div className="mt-8 mb-12 flex justify-center">
+              <div className="relative w-full max-w-xl group">
+                <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none z-10">
+                  <FontAwesomeIcon icon={faSearch} className="h-4 w-4 text-zinc-400 group-focus-within:text-[#00843D] dark:group-focus-within:text-yellow-400 transition-colors duration-300" />
+                </div>
+                <input
+                  type="text"
+                  className="block w-full pl-11 pr-4 py-3.5 border border-zinc-200 dark:border-zinc-700/50 rounded-2xl leading-5 bg-zinc-50/50 dark:bg-zinc-800/50 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-[#00843D] dark:focus:ring-yellow-400/50 focus:border-transparent sm:text-sm transition-all duration-300 shadow-sm hover:shadow-md backdrop-blur-sm"
+                  placeholder="Search for projects..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+              </div>
+            </div>
           </div>
 
           <div className="mb-16 grid grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-3">
-            {sortedProjects.map((product) => (
-              <CardProduct key={product.slug} product={product} />
-            ))}
+            <AnimatePresence mode="popLayout">
+              {filteredProjects.map((product) => (
+                <motion.div
+                  layout
+                  key={product.slug}
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.9 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  <CardProduct product={product} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+            {filteredProjects.length === 0 && (
+              <div className="col-span-full py-20 text-center">
+                <p className="text-xl text-zinc-500 dark:text-zinc-400 font-mono">
+                  No projects found matching &quot;{searchQuery}&quot;
+                </p>
+              </div>
+            )}
           </div>
 
           {/* 


### PR DESCRIPTION
### 📋 Summary
This PR implements a real-time search and filtering feature on the **Projects** page, addressing the feature request in issue #709. Users can now instantly search across all projects by name, with smooth animated transitions for matching results.

#### Key Features Implemented:
1. **Search Input UI**
   - Added a centered, styled search bar below the page heading
   - FontAwesome search icon inside the input (dynamically changes color on focus)
   - Glassmorphism styling with `backdrop-blur`, hover shadow, and smooth focus ring transitions
   - Fully responsive — works across all screen sizes
   - Supports dark mode via Tailwind dark variants
2. **Real-time Filtering Logic**
   - Used `useState` to track the live search query
   - Used `useMemo` to sort all projects alphabetically by name (memoized to avoid re-computation)
   - Used a second `useMemo` to filter sorted projects based on the trimmed, case-insensitive search query
   - Filtering is instantaneous — no debounce needed at this data scale
3. **Animated Results with Framer Motion**
   - Wrapped results in `<AnimatePresence mode="popLayout">` for smooth enter/exit animations
   - Each project card animates with `opacity` and `scale` transitions on mount/unmount
   - `layout` prop on motion divs ensures smooth reflow as results change
4. **Empty State Handling**
   - When no projects match the query, a friendly "No projects found matching ..." message is shown
   - Prevents a blank/broken-looking grid

###  Addressed Issues:
Closes #709


###  Recordings:

https://github.com/user-attachments/assets/526b4f01-d9d7-4903-919c-241f8ae6358d



### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a search field to filter projects by name in real time (case-insensitive, trimmed substring match).
  * Implemented smooth enter/exit/layout animations for projects in the grid.
  * Added an accessible ARIA live status for search updates.
  * Added an explicit empty-state message when no projects match the search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->