### PR TITLE
Fix/project card routing

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["src/*"]
     }

--- a/src/app/api/stats/route.js
+++ b/src/app/api/stats/route.js
@@ -58,7 +58,11 @@ export async function GET() {
     // Fetching contributors for ALL repos consumes too much rate limit (N requests).
     // We will proactively fetch contributors for the top 6 most starred/popular repos to get a good estimate.
     // Sorting repos by stargazers_count
-    const topRepos = repos.sort((a, b) => b.stargazers_count - a.stargazers_count).slice(0, 6);
+
+    const topRepos = [...repos]
+    .sort((a, b) => b.stargazers_count - a.stargazers_count)
+    .slice(0, 6);
+    
     
     const contributorIds = new Set();
     

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -216,6 +216,7 @@ export default function Home() {
                       heading={project.name}
                       logo={project.logo}
                       content={project.description}
+                      href={`/projects/${project.slug}`}
                     />
                   </div>
                 ))}

--- a/src/components/home/CardEffect.jsx
+++ b/src/components/home/CardEffect.jsx
@@ -3,14 +3,14 @@
 import Image from 'next/image'
 import { motion } from 'framer-motion'
 
-export function CardEffect({ heading, content, logo }) {
+export function CardEffect({ heading, content, logo, href }){
 
     const wrappedHeading = (heading ?? '')
         .replace(/([a-z])([A-Z])/g, '$1\u200B$2')
         .replace(/([A-Z])([A-Z][a-z])/g, '$1\u200B$2')
 
     return (
-        <motion.a
+        <motion.a href={href}
             initial={{ opacity: 0, rotateY: -90 }}
             whileInView={{ opacity: 1, rotateY: 0 }}
             viewport={{ once: true }}


### PR DESCRIPTION
Addressed Issues:
Fixes #726
Screenshots/Recordings:
Before:
Clicking on project cards on the homepage did not navigate to the project detail page.
After:
Project cards now correctly link to their respective project pages using /projects/[slug].
Example: /projects/pictopy, /projects/djed, etc.
Navigation works correctly in both development and production builds.
Additional Notes:
Added href navigation to the CardEffect component.
Wired homepage project cards to dynamic project routes using slug.
Verified routing behavior locally using npm run dev and production build using npm run build && npm start.
No breaking changes introduced.
AI Usage Disclosure:
☑ This PR contains AI-generated code. I have read the AI Usage Policy and this PR complies with it. I have tested the code locally and I am responsible for it.
I have used the following AI models and tools:
ChatGPT (OpenAI GPT-5.3-mini) for debugging and implementation guidance
Checklist:
☑ My PR addresses a single issue, fixes a single bug or makes a single improvement.
☑ My code follows the project's code style and conventions
☑ My changes generate no new warnings or errors
☑ I have tested locally (npm run dev and npm run build)
☑ I have joined the Discord server and will share the PR link
☑ I have read the Contribution Guidelines
☑ I have filled this PR template completely and carefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project cards in the "Our Projects" section are now clickable and navigate to individual project detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->